### PR TITLE
Tell people to use https to depend on swift-nio-zlib-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 This is a package just to be able to use zlib with SwiftPM.
 To use this package, add this to your `Package.swift` in `dependencies`:
 
-    .package(url: "git@github.com:apple/swift-nio-zlib-support.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"),
 


### PR DESCRIPTION
Motivation:

We should tell people to use https so they not need to setup ssh etc.

Modifications:

Change readme to tell to use https

Result:

Easier consuming of dependency